### PR TITLE
Fix colWidth calculation issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,8 +74,27 @@ class MagicGrid {
    * @private
    */
   colWidth () {
-    const width = this.items[0].getBoundingClientRect().width + this.gutter;
-    return Math.floor(width);
+    const width = this.container.getBoundingClientRect().width
+    let colWidth = this.items[0].getBoundingClientRect().width + this.gutter
+    let numCols = Math.floor(width / colWidth) || 1
+
+    // if we're dealing with subpixel rounding issue
+    // reduce the colWidth until we have a proper layout
+    // we know we should be able to fit one more column
+    // limit number of iterations to minimise overhead
+    // and to prevent any risk of infinite loop
+    if (Math.floor(colWidth) === Math.floor(width % colWidth)) {
+      const properNumCols = numCols + 1
+      let iterationCount = 0
+      const maxIterations = 20
+      while (numCols !== properNumCols && iterationCount < maxIterations) {
+        iterationCount += 1
+        colWidth -= 0.0001
+        numCols = Math.floor(width / colWidth)
+      }
+    }
+
+    return colWidth
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,8 @@ class MagicGrid {
    * @private
    */
   colWidth () {
-    return this.items[0].getBoundingClientRect().width + this.gutter;
+    const width = this.items[0].getBoundingClientRect().width + this.gutter;
+    return Math.floor(width);
   }
 
   /**


### PR DESCRIPTION
There are sub-pixel differences between col widths returned by different browsers, when the width is not defined in absolute pixel values, e.g. a percentage. In Firefox, for example, it causes a three column layout to be rendered as a two column layout.

See this fiddle forked from your example in the README: https://jsfiddle.net/avwgdurp/
When you resize the preview container you notice in Firefox the layout jumps between 2 and 3 columns, whereas in Chrome there are always 3 columns rendered.

Chrome:
![chrome](https://user-images.githubusercontent.com/998924/53681121-f90b7b00-3ce4-11e9-8ffd-581916ed2956.gif)

Firefox:
![firefox](https://user-images.githubusercontent.com/998924/53681123-fe68c580-3ce4-11e9-842e-08ad8485df21.gif)


This change floors the col width value to the whole pixel, ensuring their combined width is never wider than the container.