### PR TITLE
Keep css transition

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ class MagicGrid {
       style.position = "absolute";
   
       if (this.animate) {
-        style.transition = `${this.useTransform ? "transform" : "top, left"} 0.2s ease`;
+        style.transition = getComputedStyle(this.items[i]).transition + ", " + `${this.useTransform ? "transform" : "top, left"} 0.2s ease`;
       }
     }
 


### PR DESCRIPTION
I have background-color transition for items but animation doesn't work. So I'm faced with a problem due css transition was overridden by magic-grid if set `animate: true` . 

