### PR TITLE
Ignore items without height (ie items with "display: none")

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ class MagicGrid extends EventEmitter{
       let style = items[i].style;
 
       style.position = "absolute";
-  
+
       if (this.animate) {
         style.transition = `${this.useTransform ? "transform" : "top, left"} 0.2s ease`;
       }
@@ -171,7 +171,9 @@ class MagicGrid extends EventEmitter{
         item.style.left = left;
       }
 
-      col.height += item.getBoundingClientRect().height + topGutter;
+      if ( item.getBoundingClientRect().height > 0 ) {
+        col.height += item.getBoundingClientRect().height + topGutter;
+      }
 
       if(col.height > maxHeight){
         maxHeight = col.height;


### PR DESCRIPTION
This adds a check to see if the item has a height greater than zero before adding it to the column height.

Right now, if an item is set to `display: none`, the gutter height will still be added to the container, resulting in a container that is taller than the visible items. This check prevents that from happening.